### PR TITLE
Fix KeyError crash when missing release_date for cancelled movies and shows

### DIFF
--- a/theaterTrailers.py
+++ b/theaterTrailers.py
@@ -109,7 +109,11 @@ def main():
           tempList = search.results
           tempList.reverse()
           for s in tempList:
-            releaseDate = s['release_date']
+            try:
+              releaseDate = s['release_date']
+            except KeyError as e:
+              logger.warn("The movie does not have a release date -> cancelled? Skipping trailer...")
+              continue
             movieTMDBID = s['id']
             releaseDateList = releaseDate.split('-')
             try:


### PR DESCRIPTION
Right now, the script fails when there is a movie that has no release_date set (which is an optional field).
This change ensures that whenever there is no release_date, it assumes the movie/show is cancelled, and hence there is no need to download that trailer.